### PR TITLE
Fix package main

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd react-simplemde-editor
 npm install
 cd demo
 gulp
-open browser to localhost:3000
+open browser to localhost:5555
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react": "^0.14.2",
     "simplemde": "^1.11.2"
   },
-  "main": "src/index.js",
+  "main": "dist/react-simplemde-editor.js",
   "devDependencies": {
     "babel-core": "^6.3.15",
     "babel-loader": "^6.2.0",


### PR DESCRIPTION
The current package.json main points to src/index.js which includes ES2015 syntax. This causes a problem in older browsers like Safari 9.  It really boils down to one `let _id = 0;` in services/idGenerator.js`

