### PR TITLE
Fix typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note - while SimpleMDE options has an `initialValue` option, this component only
 var React = require('react');
 var SimpleMDE = require('react-simplemde-editor');
 
-<SimpleMDEReact
+<SimpleMDE
   onChange={this.handleChange}
   options={{
     autofocus: true,
@@ -81,7 +81,7 @@ extraKeys = {
   }
 };
 
-<SimpleMDEReact
+<SimpleMDE
   onChange={this.handleChange}
   extraKeys={extraKeys}
 />


### PR DESCRIPTION
There is a small typos in examples. Showing that we import with name SimpleMDE, but in JSX Markup we have SimpleMDEReact instead.