### PR TITLE
Fix typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ var SimpleMDE = require('react-simplemde-editor');
 
 <SimpleMDE
   onChange={this.handleChange}
+  value={this.state.textValue}
   options={{
     autofocus: true,
     spellChecker: false,
-    value: this.state.textValue
     // etc.
   }}
 />


### PR DESCRIPTION
Another typo :)  If you put `value` in `options` object it's not set the value. Value must be outside the options as a component prop `value`.
