### PR TITLE
- Requiring Codemirror outside of a browser context results in errors…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+end_of_line = lf
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ var SimpleMDE = require('react-simplemde-editor');
 
 <SimpleMDE
   onChange={this.handleChange}
+  value={this.state.textValue}
   options={{
     autofocus: true,
     spellChecker: false,
-    value: this.state.textValue
     // etc.
   }}
 />

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 const React = require('react');
-const SimpleMDE = require('simplemde/dist/simplemde.min');
 const generateId = require('./services/idGenerator');
 const NOOP = require('./utils/noop');
 
@@ -19,7 +18,12 @@ module.exports = React.createClass({
   },
 
   componentWillMount: function() {
-    this.id = generateId();
+    const id = this.props.id;
+    if (id) {
+      this.id = id;
+    } else {
+      this.id = generateId();
+    }
   },
 
   componentDidMount: function() {
@@ -43,8 +47,10 @@ module.exports = React.createClass({
   },
 
   createEditor: function() {
+    const SimpleMDE = require('simplemde/src/js/simplemde.js');
     const initialOptions = {
-      element: document.getElementById(this.id)
+      element: document.getElementById(this.id),
+      initialValue: this.props.value
     };
 
     const allOptions = Object.assign({}, initialOptions, this.props.options);


### PR DESCRIPTION
- In order to support server rendering, this lazily requires SimpleMDE (which uses Codemirror under the hood) from React component lifecycle events.
- Workaround to achieve sync in client-server ID's by giving ability to set up custom ID's as props added.
- Initial value was missing in textbox when redirect using react-router with already prepared state. `initialValue` option is mapped to `this.props.value ` on SimpleMDE instance creation.
- Readme typo with `value` inside in `options` fixed to avoid confusion
- .editorconfig added to keep consistency in code indentation rules etc.

Fixes #27 #29  #30